### PR TITLE
Enable Continuous Integration using Circle CI and disable KVM acceleration

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,5 @@
+FROM fedora:latest
+RUN dnf install -y git openssh \
+	edk2-ovmf qemu-system-x86 \
+	python2 python2-requests \
+	python3 python3-requests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: puiterwijk/qemu-ovmf-secureboot:testenv
+
+    steps:
+      - checkout
+
+      - run:
+          name: run simple version with python2
+          command: |
+            python2 ./ovmf-vars-generator --verbose --print-output --kernel-path vmlinuz --initrd-path initrd.img output2.vars
+
+      - store_artifacts:
+          path: output2.vars

--- a/ovmf-vars-generator
+++ b/ovmf-vars-generator
@@ -26,9 +26,12 @@ def strip_special(line):
 
 
 def generate_qemu_cmd(args, readonly, *extra_args):
+    machinetype = 'q35,smm=on'
+    if args.enable_kvm:
+        machinetype += ',accel=kvm'
     return [
         args.qemu_binary,
-        '-machine', 'q35,smm=on,accel=kvm',
+        '-machine', machinetype,
         '-display', 'none',
         '-no-user-config',
         '-nodefaults',
@@ -160,6 +163,8 @@ def parse_args():
                         action='store_true')
     parser.add_argument('--qemu-binary', help='QEMU binary path',
                         default='/usr/bin/qemu-system-x86_64')
+    parser.add_argument('--enable-kvm', help='Enable KVM acceleration',
+                        action='store_true')
     parser.add_argument('--ovmf-binary', help='OVMF secureboot code file',
                         default='/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd')
     parser.add_argument('--ovmf-template-vars', help='OVMF empty vars file',


### PR DESCRIPTION
This PR will enable CI testing using CircleCI, and disabled KVM acceleration.

The KVM acceleration is unfortunately unavailable inside the container, but it should be fine to disable it anyway.
The script will be slightly slower, but a lot more portable.