### PR TITLE
Select the TCG accelerator explicitly in the absence of "--enable-kvm"

### DIFF
--- a/ovmf-vars-generator
+++ b/ovmf-vars-generator
@@ -31,8 +31,7 @@ def generate_qemu_cmd(args, readonly, *extra_args):
         machinetype = 'pc'
     else:
         machinetype = 'q35,smm=on'
-    if args.enable_kvm:
-        machinetype += ',accel=kvm'
+    machinetype += ',accel=%s' % ('kvm' if args.enable_kvm else 'tcg')
     return [
         args.qemu_binary,
         '-machine', machinetype,


### PR DESCRIPTION
Some QEMU binaries, such as "/usr/libexec/qemu-kvm" in base RHEL7, do not
default to pure TCG like upstream QEMU does. Instead, they have the
accelerator string "kvm:tcg" built-in, which -- in the absence of an
explicit "accel=..." machine property -- first attempts KVM, and falls
back to TCG if KVM is unavailable.

When this occurs, the following messages are printed:

> char device redirected to /dev/pts/8 (label charserial1)
> Could not access KVM kernel module: No such file or directory
> failed to initialize KVM: No such file or directory
> Back to tcg accelerator.

While the enroll_keys() method expects the first line of the above, it is
thrown off by the other three lines, and the enrollment gets stuck at

> INFO:root:Starting enrollment
> INFO:root:Performing enrollment

Fix this issue by always selecting TCG vs. KVM explicitly, such that the
upstream QEMU behavior is followed regardless of downstream accel
preferences. When TCG is chosen explicitly, the fallback lines are not
printed, and enroll_keys() succeeds.

Signed-off-by: Laszlo Ersek <lersek@redhat.com>