### PR TITLE
Remove references to 'initrd' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ paths and URLs:
         --fedora-version 27 \
         --kernel-path /tmp/qosb.kernel \
         --kernel-url https://download.fedoraproject.org/pub/fedora/linux/releases/27/Everything/x86_64/os/images/pxeboot/vmlinuz \
-        --initrd-path /tmp/qosb.initrd \
-        --initrd-url https://download.fedoraproject.org/pub/fedora/linux/releases/27/Everything/x86_64/os/images/pxeboot/initrd.img \
         another-output-VARS.fd
 
 


### PR DESCRIPTION
Commit 3ef26274b192872d519cebf5bc0699ba97f6f5ea ("Remove all uses of
initrd") removed the '--initrd' parameter, but inadvertently missed to
update the README to reflect that.

Update it now.

Signed-off-by: Kashyap Chamarthy <kchamart@redhat.com>