### PR TITLE
bump guest RAM size to 768 MiB

### DIFF
--- a/ovmf-vars-generator
+++ b/ovmf-vars-generator
@@ -48,7 +48,7 @@ def generate_qemu_cmd(args, readonly, *extra_args):
         '-display', 'none',
         '-no-user-config',
         '-nodefaults',
-        '-m', '256',
+        '-m', '768',
         '-smp', '2,sockets=2,cores=1,threads=1',
         '-chardev', 'pty,id=charserial1',
         '-device', 'isa-serial,chardev=charserial1,id=serial1',


### PR DESCRIPTION
With the current 256 MiB guest RAM size, kernel 4.18.0-161.el8.x86_64
fails to boot:

> EFI stub: UEFI Secure Boot is enabled.
> EFI stub: ERROR: Failed to allocate usable memory for kernel.
> efi_relocate_kernel() failed!
> efi_main() failed!

at which point the guest kernel hangs voluntarily, so we never complete
the varstore template verification.

According to
<https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_installation/system-requirements-reference_installing-rhel#check-disk-and-memory-requirements_system-requirements-reference>,
"Table B.1. Minimum RAM requirements", a RAM size of 768 MiB suffices for
a "Local media installation" of RHEL8. Given that our use case does not
involve any userspace payload (such as Anaconda etc), 768 MiB is good
enough for us too. Bump the "-m" option's argument accordingly.

Signed-off-by: Laszlo Ersek <lersek@redhat.com>