### PR TITLE
Remove Python2 support

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,5 +1,4 @@
 FROM fedora:latest
 RUN dnf install -y git openssh \
 	edk2-ovmf qemu-system-x86 \
-	python2 python2-requests \
 	python3 python3-requests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,6 @@ jobs:
       - checkout
 
       - run:
-          name: run simple version with python2
-          command: |
-            python2 ./ovmf-vars-generator --verbose --print-output --kernel-path vmlinuz output2.vars
-
-      - run:
           name: run simple version with python3
           command: |
             python3 ./ovmf-vars-generator --verbose --print-output --kernel-path vmlinuz output3.vars
@@ -26,9 +21,6 @@ jobs:
           name: run testing-only
           command: |
             python3 ./ovmf-vars-generator --verbose --print-output --kernel-path vmlinuz outputsplit.vars --skip-enrollment
-
-      - store_artifacts:
-          path: output2.vars
 
       - store_artifacts:
           path: output3.vars


### PR DESCRIPTION
Few days left before Python2 get unmaintained.
Time to remove it.

This might resolve the Circle CI failures.