### PR TITLE
Unbreak Circle CI, and other fixes

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -3,3 +3,4 @@ RUN dnf install -y git openssh \
 	edk2-ovmf qemu-system-x86 \
 	python2 python2-requests \
 	python3 python3-requests
+ADD https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/27/Everything/x86_64/os/images/pxeboot/vmlinuz .

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:31
 RUN dnf install -y git openssh \
 	edk2-ovmf qemu-system-x86 \
 	python2 python2-requests \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   gen_cert:
     docker:
-      - image: puiterwijk/qemu-ovmf-secureboot:testenv
+      - image: rhuefi/qemu-ovmf-secureboot:testenv
 
     steps:
       - checkout
@@ -20,7 +20,7 @@ jobs:
 
   test:
     docker:
-      - image: puiterwijk/qemu-ovmf-secureboot:testenv
+      - image: rhuefi/qemu-ovmf-secureboot:testenv
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  gen_cert:
     docker:
       - image: puiterwijk/qemu-ovmf-secureboot:testenv
 
@@ -8,19 +8,40 @@ jobs:
       - checkout
 
       - run:
+          name: generate PK/KEK OEM strings
+          command: |
+            openssl req -x509 -newkey rsa:2048 -nodes -subj "/C=XX/ST=Test/L=EnrollTest/O=Xxx/CN=www.example.com" -outform PEM -keyout PkKek1.private.key -out PkKek1.pem
+            sed -e 's/^-----BEGIN CERTIFICATE-----$/4e32566d-8e9e-4f52-81d3-5bb9715f9727:/' -e '/^-----END CERTIFICATE-----$/d' PkKek1.pem > PkKek1.oemstr
+
+      - save_cache:
+          key: asset-cache-v1
+          paths:
+            - PkKek1.oemstr
+
+  test:
+    docker:
+      - image: puiterwijk/qemu-ovmf-secureboot:testenv
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: asset-cache-v1
+
+      - run:
           name: run simple version with python2
           command: |
-            python2 ./ovmf-vars-generator --verbose --print-output --kernel-path vmlinuz output2.vars
+            python2 ./ovmf-vars-generator --verbose --print-output --kernel-path vmlinuz output2.vars --oem-string "$(< PkKek1.oemstr)"
 
       - run:
           name: run simple version with python3
           command: |
-            python3 ./ovmf-vars-generator --verbose --print-output --kernel-path vmlinuz output3.vars
+            python3 ./ovmf-vars-generator --verbose --print-output --kernel-path vmlinuz output3.vars --oem-string "$(< PkKek1.oemstr)"
 
       - run:
           name: run enrollment-only
           command: |
-            python3 ./ovmf-vars-generator --verbose --print-output --kernel-path vmlinuz outputsplit.vars --skip-testing
+            python3 ./ovmf-vars-generator --verbose --print-output --kernel-path vmlinuz outputsplit.vars --skip-testing --oem-string "$(< PkKek1.oemstr)"
 
       - run:
           name: run testing-only
@@ -32,3 +53,12 @@ jobs:
 
       - store_artifacts:
           path: output3.vars
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - gen_cert
+      - test:
+          requires:
+            - gen_cert

--- a/ovmf-vars-generator
+++ b/ovmf-vars-generator
@@ -212,9 +212,9 @@ def parse_args():
                         help='Fedora version to get kernel for checking',
                         default='27')
     parser.add_argument('--kernel-url', help='Kernel URL',
-                        default='https://download.fedoraproject.org/pub/fedora'
-                                '/linux/releases/%(version)s/Everything/x86_64'
-                                '/os/images/pxeboot/vmlinuz')
+                        default='https://archives.fedoraproject.org/pub'
+                                '/archive/fedora/linux/releases/%(version)s'
+                                '/Everything/x86_64/os/images/pxeboot/vmlinuz')
     parser.add_argument('--disable-smm',
                         help=('Don\'t restrict varstore pflash writes to '
                               'guest code that executes in SMM. Use this '

--- a/ovmf-vars-generator
+++ b/ovmf-vars-generator
@@ -128,7 +128,7 @@ def enroll_keys(args):
     p.stdin.flush()
     while True:
         read = p.stdout.readline()
-        if args.print_output:
+        if args.print_output and len(read):
             print('OUT: %s' % strip_special(read), end='')
             print()
         if b'info: success' in read:
@@ -160,7 +160,7 @@ def test_keys(args):
         logging.info('Performing verification')
         while True:
             read = p.stdout.readline()
-            if args.print_output:
+            if args.print_output and len(read):
                 print('OUT: %s' % strip_special(read), end='')
                 print()
             if b'Secure boot disabled' in read:

--- a/ovmf-vars-generator
+++ b/ovmf-vars-generator
@@ -132,6 +132,8 @@ def enroll_keys(args):
             print()
         if b'info: success' in read:
             break
+        elif b'Reset with <null string>' in read:
+            break
     p.wait()
     if args.print_output:
         print(strip_special(p.stdout.read()), end='')

--- a/ovmf-vars-generator
+++ b/ovmf-vars-generator
@@ -46,6 +46,7 @@ def generate_qemu_cmd(args, readonly, *extra_args):
         args.qemu_binary,
         '-machine', machinetype,
         '-display', 'none',
+        '-no-reboot',
         '-no-user-config',
         '-nodefaults',
         '-m', '768',


### PR DESCRIPTION
Fix the Circle CI:
- Update Fedora kernel URL
- Use recent Fedora with recent QEMU
- Few fixes to avoid the script looping for hours on CI

Due to Tianocore BZ#1747 change in EnrollDefaultKeys,
generate a temporary X509 certificate to run the test.