### PR TITLE
Use python3 interpreter in your path instead of hardcoding /bin/python3

### DIFF
--- a/ovmf-vars-generator
+++ b/ovmf-vars-generator
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/env python3
 # Copyright (C) 2017 Red Hat
 # Authors:
 # - Patrick Uiterwijk <puiterwijk@redhat.com>


### PR DESCRIPTION
On Debian-based systems, python3 is in /usr/bin.

Signed-off-by: dann frazier <dann.frazier@canonical.com>