### PR TITLE
Qemu: Use max cpu

### DIFF
--- a/ovmf-vars-generator
+++ b/ovmf-vars-generator
@@ -47,6 +47,7 @@ def generate_qemu_cmd(args, readonly, *extra_args):
         '-machine', machinetype,
         '-display', 'none',
         '-no-reboot',
+        '-cpu', 'max',
         '-no-user-config',
         '-nodefaults',
         '-m', '768',


### PR DESCRIPTION
RHEL qemu-kvm recently added warnings for obsolete cpus. These warnings
break ovmf-vars-generator handling so it get stuck and never finishes.

Using `-cpu max` always uses the model with the most featues and thus
eliminates this warning. This should not impact the use of other
versions of Qemu.

Signed-off-by: Miroslav Rezanina <mrezanin@redhat.com>
Signed-off-by: Oliver Steffen <osteffen@redhat.com>