### PR TITLE
Add a delay before sending commands

### DIFF
--- a/ovmf-vars-generator
+++ b/ovmf-vars-generator
@@ -20,6 +20,7 @@ import tempfile
 import shutil
 import string
 import subprocess
+import time
 
 
 def strip_special(line):
@@ -116,6 +117,8 @@ def enroll_keys(args):
     if args.print_output:
         print(strip_special(read), end='')
         print()
+    # Give firmware some time to boot past boot manager
+    time.sleep(2)
     # Send the escape char to enter the UEFI shell early
     p.stdin.write(b'\x1b')
     p.stdin.flush()


### PR DESCRIPTION
Under some circumstances the firmware might take a little longer to reach the UEFI shell. If the `ESC` key is send and we are still in the Boot Manager phase where hotkeys are active, we might end up booting into the firmware menu instead.

Add a 2 second delay before sending the commands to increase the probability of actually having reached the shell.

The problem occurred here: https://gitlab.com/redhat/rhel/src/edk2/-/merge_requests/104